### PR TITLE
Expand search for FPM binary

### DIFF
--- a/exec_fpm.sh
+++ b/exec_fpm.sh
@@ -13,7 +13,7 @@ if [ -z "$ruby" ]; then
 	exit 1
 fi
 
-fpm=`find /var/lib/gems/ /usr/lib*/ruby/gems/ -path "*/gems/fpm-*/bin/fpm" 2> /dev/null`
+fpm=`find /var/lib/gems/ /usr/local/share/gems/ /usr/lib*/ruby/gems/ -path "*/gems/fpm-*/bin/fpm" 2> /dev/null`
 if [ -z "$fpm" ]; then
 	echo "didn't find fpm, assuming it isn't installed"
 	exit 1


### PR DESCRIPTION
Add another directory to the search for FPM binary since
RHEL installs FPM under /usr/local/share/gems/.

Resolves PROD-568

ChangeLog:
 -