### PR TITLE
Fix windows build

### DIFF
--- a/WindowsInstaller/WindowsInstaller.wixproj
+++ b/WindowsInstaller/WindowsInstaller.wixproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <EnableProjectHarvesting>True</EnableProjectHarvesting>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>3.5</ProductVersion>


### PR DESCRIPTION
Enable WiX project harvesting, which is by default disabled in WiX
versions greater than 3.5.

Resolves PROD-570

ChangeLog:
 -